### PR TITLE
Fix Rubocop configuration

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,6 +5,6 @@
 inherit_from:
   - https://raw.githubusercontent.com/riboseinc/oss-guides/master/ci/rubocop.yml
 AllCops:
-  TargetRubyVersion: 2.3
+  TargetRubyVersion: 2.4
 Rails:
   Enabled: true


### PR DESCRIPTION
Changing target Ruby version in Rubocop configuration to 2.4, so that it matches minimum Ruby version specified in the gemspec.

Moreover, it actually makes Rubocop working again, because Rubocop 1.5 that we have updated our guides for does not recognize targets lower than Ruby 2.4.