### PR TITLE
Disable some Rubocop checks

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,3 +12,9 @@ Rails:
 # Dependencies are ordered for purpose.
 Gemspec/OrderedDependencies:
   Enabled: false
+
+# TODO Rather than disabling, change severity to "info" in Rubocop 1.9+.
+Layout:
+  Enabled: false
+Style/StringLiterals:
+  Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,3 +8,7 @@ AllCops:
   TargetRubyVersion: 2.4
 Rails:
   Enabled: false
+
+# Dependencies are ordered for purpose.
+Gemspec/OrderedDependencies:
+  Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,4 +7,4 @@ inherit_from:
 AllCops:
   TargetRubyVersion: 2.4
 Rails:
-  Enabled: true
+  Enabled: false


### PR DESCRIPTION
- Disable checks for most frequent code style violations, as fixing them would lead to a so huge diff noise that we can't handle yet.
- Disable Rails-specific checks, as it's not a Rails application.
- Disable checks for alphabetic order of dependencies, as their current order is for purpose.

This pull request reduces the number of reported code style offences from 760 to just 112.
