### PR TITLE
(Hotfix) Bold/italics asciidoc symbols within word should not be escaped

### DIFF
--- a/lib/reverse_adoc/converters/base.rb
+++ b/lib/reverse_adoc/converters/base.rb
@@ -12,7 +12,9 @@ module ReverseAdoc
       end
 
       def escape_keychars(string)
-        string.gsub(/(?<!\\)[*_]/, '*' => '\*', '_' => '\_')
+        string
+          .gsub(/(?<!\\)_+\b|\b(?<!\\)_+/) { |n| n.chars.map {|_| '\_'}.join }
+          .gsub(/(?<!\\)\*/, '\*')
       end
 
       def extract_title(node)

--- a/spec/assets/escapables.html
+++ b/spec/assets/escapables.html
@@ -6,6 +6,7 @@
     ***three asterisks***
     __two underscores__
     ___three underscores___
+    ___three__underscores___ and another_undersocre
 
     some text...
 

--- a/spec/components/escapables_spec.rb
+++ b/spec/components/escapables_spec.rb
@@ -16,6 +16,11 @@ describe ReverseAdoc do
     it { is_expected.to include ' \_\_\_three underscores\_\_\_ ' }
   end
 
+  context "multiple underscores with undersocre inside words and new lines" do
+    it { is_expected.to include 'another_undersocre' }
+    it { is_expected.to include ' \_\_\_three__underscores\_\_\_ ' }
+  end
+
   context "underscores within words in code blocks" do
     it { is_expected.to include "....\n<code>var theoretical_max_infin = 1.0;</code>\n....\n" }
   end


### PR DESCRIPTION
https://github.com/metanorma/reverse_adoc/issues/70 dont escape undersocre inside words