### PR TITLE
(Hotfix) italic bold symbols inside words should not be escaped

### DIFF
--- a/lib/reverse_adoc/converters/base.rb
+++ b/lib/reverse_adoc/converters/base.rb
@@ -12,9 +12,9 @@ module ReverseAdoc
       end
 
       def escape_keychars(string)
+        subs = { '*' => '\*', '_' => '\_' }
         string
-          .gsub(/(?<!\\)_+\b|\b(?<!\\)_+/) { |n| n.chars.map {|_| '\_'}.join }
-          .gsub(/(?<!\\)\*/, '\*')
+          .gsub(/((?<=\s)[\*_]+)|[\*_]+(?=\s)/) { |n| n.chars.map { |char| subs[char] }.join }
       end
 
       def extract_title(node)

--- a/spec/assets/escapables.html
+++ b/spec/assets/escapables.html
@@ -4,6 +4,7 @@
 
     **two asterisks**
     ***three asterisks***
+    ***three *and*the* asterisc*word and asterisc**multword asterisks***
     __two underscores__
     ___three underscores___
     ___three__underscores___ and another_undersocre

--- a/spec/components/escapables_spec.rb
+++ b/spec/components/escapables_spec.rb
@@ -9,6 +9,9 @@ describe ReverseAdoc do
   context "multiple asterisks" do
     it { is_expected.to include ' \*\*two asterisks\*\* ' }
     it { is_expected.to include ' \*\*\*three asterisks\*\*\* ' }
+    it { is_expected.to include ' \*and*the\* ' }
+    it { is_expected.to include ' asterisc*word ' }
+    it { is_expected.to include ' asterisc**multword asterisks\*\*\* ' }
   end
 
   context "multiple underscores" do


### PR DESCRIPTION
https://github.com/metanorma/reverse_adoc/issues/70 also dont escape asterisc chars inside words