### PR TITLE
fixing `pre` tag conversion

### DIFF
--- a/lib/reverse_adoc/converters/pre.rb
+++ b/lib/reverse_adoc/converters/pre.rb
@@ -16,7 +16,11 @@ module ReverseAdoc
       private
 
       def treat(node, state)
-        node.to_s
+        return "\n" if node.name == "br"
+
+        prefix = postfix = "\n\n" if node.name == "p"
+
+        "#{prefix}#{node.text}#{postfix}"
       end
 
       def language(node)

--- a/spec/components/code_spec.rb
+++ b/spec/components/code_spec.rb
@@ -7,13 +7,13 @@ describe ReverseAdoc do
   subject { ReverseAdoc.convert(input) }
 
   it { is_expected.to match /inline `code` block/ }
-  it { is_expected.to match /\nvar this\;\nthis\.is/ }
+  it { is_expected.to match /\nvar this;\nthis\.is/ }
   it { is_expected.to match /block"\)\nconsole/ }
 
   context "with github style code blocks" do
     subject { ReverseAdoc.convert(input) }
     it { is_expected.to match /inline `code` block/ }
-    it { is_expected.to match /\n\.\.\.\.\nvar this\;\nthis/ }
+    it { is_expected.to match /\n\.\.\.\.\nvar this;\nthis/ }
     it { is_expected.to match /it is"\) ?\n	\n\.\.\.\./ }
   end
 

--- a/spec/components/code_spec.rb
+++ b/spec/components/code_spec.rb
@@ -7,19 +7,19 @@ describe ReverseAdoc do
   subject { ReverseAdoc.convert(input) }
 
   it { is_expected.to match /inline `code` block/ }
-  it { is_expected.to match /\n<code>var this\;\nthis\.is/ }
+  it { is_expected.to match /\nvar this\;\nthis\.is/ }
   it { is_expected.to match /block"\)\nconsole/ }
 
   context "with github style code blocks" do
     subject { ReverseAdoc.convert(input) }
     it { is_expected.to match /inline `code` block/ }
-    it { is_expected.to match /\n\.\.\.\.\n<code>var this\;\nthis/ }
-    it { is_expected.to match /it is"\) ?\n	<\/code>\n\.\.\.\./ }
+    it { is_expected.to match /\n\.\.\.\.\nvar this\;\nthis/ }
+    it { is_expected.to match /it is"\) ?\n	\n\.\.\.\./ }
   end
 
   context "code with indentation" do
     subject { ReverseAdoc.convert(input) }
-    it { is_expected.to match(/^<code>tell application "Foo"\n/) }
+    it { is_expected.to match(/^tell application "Foo"\n/) }
     it { is_expected.to match(/^    beep\n/) }
     it { is_expected.to match(/^end tell\n/) }
   end

--- a/spec/components/escapables_spec.rb
+++ b/spec/components/escapables_spec.rb
@@ -25,7 +25,7 @@ describe ReverseAdoc do
   end
 
   context "underscores within words in code blocks" do
-    it { is_expected.to include "....\n<code>var theoretical_max_infin = 1.0;</code>\n....\n" }
+    it { is_expected.to include "....\nvar theoretical_max_infin = 1.0;\n....\n" }
   end
 
 end

--- a/spec/components/escapables_spec.rb
+++ b/spec/components/escapables_spec.rb
@@ -25,7 +25,8 @@ describe ReverseAdoc do
   end
 
   context "underscores within words in code blocks" do
-    it { is_expected.to include "....\nvar theoretical_max_infin = 1.0;\n....\n" }
+    let(:expected_output) { "....\nvar theoretical_max_infin = 1.0;\n....\n" }
+    it { is_expected.to include expected_output }
   end
 
 end

--- a/spec/components/paragraphs_spec.rb
+++ b/spec/components/paragraphs_spec.rb
@@ -8,7 +8,7 @@ describe ReverseAdoc do
 
   it { is_expected.not_to start_with "\n\n" }
   it { is_expected.to start_with "First content\n\nSecond content\n\n" }
-  it { is_expected.to include "\n\n_Complex_\n\n\.\.\.\.\n\n        <code>Content</code>\n" }
+  it { is_expected.to include "\n\n_Complex_\n\n\.\.\.\.\n\n        Content\n" }
   it { is_expected.to include "*Trailing whitespace:*" }
   it { is_expected.to include "*Trailing non-breaking space:&nbsp;*" }
   it { is_expected.to include "*_Combination:&nbsp;_*" }

--- a/spec/components/quotation_spec.rb
+++ b/spec/components/quotation_spec.rb
@@ -6,7 +6,7 @@ describe ReverseAdoc do
   let(:document) { Nokogiri::HTML(input) }
   subject { ReverseAdoc.convert(input) }
 
-  it { is_expected.to match /\n      <code>Block of code<\/code>$/ }
+  it { is_expected.to match /\n      Block of code$/ }
   it { is_expected.to include "\n____\nFirst quoted paragraph\n\nSecond quoted paragraph\n____\n" }
 
 end

--- a/spec/lib/reverse_adoc/converters/pre_spec.rb
+++ b/spec/lib/reverse_adoc/converters/pre_spec.rb
@@ -21,7 +21,7 @@ describe ReverseAdoc::Converters::Pre do
 
   it 'preserves xml' do
     node = node_for("<pre><code>x</code><br/><p>hello</p></pre>")
-    expect(converter.convert(node)).to include "....\n<code>x</code><br><p>hello</p>\n....\n"
+    expect(converter.convert(node)).to include "....\nx\n\n\nhello\n\n\n....\n"
   end
 
   context 'syntax highlighting' do


### PR DESCRIPTION
Updated the `<pre>` tag conversion

**Input**

```
<pre><code>PROMPT&gt;</code></pre>
```

**New Output**

```
....
PROMPT>
....
```

**Old Output**
```
....
<code>PROMPT&gt;</code>
....
```

closes #78 