### PR TITLE
bugfix: escape link like formation in text

### DIFF
--- a/lib/reverse_adoc/converters/text.rb
+++ b/lib/reverse_adoc/converters/text.rb
@@ -32,7 +32,7 @@ module ReverseAdoc
         text = escape_keychars(text)
 
         text = preserve_keychars_within_backticks(text)
-        text = preserve_tags(text)
+        text = escape_links(text)
 
         text
       end
@@ -41,8 +41,8 @@ module ReverseAdoc
         text.gsub(/\u00A0/, "&nbsp;")
       end
 
-      def preserve_tags(text)
-        text.gsub(/[<>]/, '>' => '\>', '<' => '\<')
+      def escape_links(text)
+        text.gsub(/<<([^>]*)>>/, "\\<<\\1>>")
       end
 
       def remove_border_newlines(text)

--- a/lib/reverse_adoc/converters/text.rb
+++ b/lib/reverse_adoc/converters/text.rb
@@ -32,9 +32,7 @@ module ReverseAdoc
         text = escape_keychars(text)
 
         text = preserve_keychars_within_backticks(text)
-        text = escape_links(text)
-
-        text
+        escape_links(text)
       end
 
       def preserve_nbsp(text)

--- a/spec/lib/reverse_adoc/converters/text_spec.rb
+++ b/spec/lib/reverse_adoc/converters/text_spec.rb
@@ -28,13 +28,13 @@ describe ReverseAdoc::Converters::Text do
     expect(result).to eq "foo&nbsp;bar &nbsp;"
   end
 
-  it 'keeps HTML characters' do
+  it "keeps HTML characters" do
     input = node_for("<p>&lt;foo&gt;</p>")
     result = converter.convert(input)
-    expect(result).to eq '<foo>'
+    expect(result).to eq "<foo>"
   end
 
-  it 'escapes Link like characters in text' do
+  it "escapes Link like characters in text" do
     input = node_for("<p>&lt;&lt;foo&gt;&gt;</p>")
     result = converter.convert(input)
     expect(result).to eq '\<<foo>>'

--- a/spec/lib/reverse_adoc/converters/text_spec.rb
+++ b/spec/lib/reverse_adoc/converters/text_spec.rb
@@ -28,10 +28,16 @@ describe ReverseAdoc::Converters::Text do
     expect(result).to eq "foo&nbsp;bar &nbsp;"
   end
 
-  it 'keeps escaped HTML-ish characters' do
+  it 'keeps HTML characters' do
     input = node_for("<p>&lt;foo&gt;</p>")
     result = converter.convert(input)
-    expect(result).to eq '\<foo\>'
+    expect(result).to eq '<foo>'
+  end
+
+  it 'escapes Link like characters in text' do
+    input = node_for("<p>&lt;&lt;foo&gt;&gt;</p>")
+    result = converter.convert(input)
+    expect(result).to eq '\<<foo>>'
   end
 
   context 'within backticks' do


### PR DESCRIPTION
Escape link like combination in text e.g convert `<<text>>` to `\<<text>>`

fixes #82 
